### PR TITLE
fix hot_standby_feedback parameter as unmodifiable

### DIFF
--- a/doc_source/AuroraPostgreSQL.Reference.md
+++ b/doc_source/AuroraPostgreSQL.Reference.md
@@ -137,7 +137,7 @@ The following table shows all of the parameters that apply to a specific DB inst
 | `gin_fuzzy_search_limit` | Yes | 
 | `gin_pending_list_limit` | Yes | 
 | `hba_file` | No | 
-| `hot_standby_feedback` | Yes | 
+| `hot_standby_feedback` | No | 
 | `ident_file` | No | 
 | `idle_in_transaction_session_timeout` | Yes | 
 | `join_collapse_limit` | Yes | 


### PR DESCRIPTION
*Issue #, if available:*
`hot_standby_feedback` is unmodifiable parameter on RDS Aurora(PostgreSQL Compatible) parameter group.

*Description of changes:*
Modify `hot_standby_feedback` to `No`
