### PR TITLE
Replaces some "MySQL" for "PostgreSQL"

### DIFF
--- a/doc_source/AuroraPostgreSQL.Migrating.RDSPostgreSQL.Replica.md
+++ b/doc_source/AuroraPostgreSQL.Migrating.RDSPostgreSQL.Replica.md
@@ -130,7 +130,7 @@ You can create a new Aurora DB cluster for an Aurora Read Replica from a source 
 
   The list of EC2 VPC security groups to associate with this DB cluster\.
 
-In this example, you create a DB cluster named *myreadreplicacluster* from a source PostgreSQL DB instance with an ARN set to *mysqlmasterARN*, associated with a DB subnet group named *mysubnetgroup* and a VPC security group named *mysecuritygroup*\.
+In this example, you create a DB cluster named *myreadreplicacluster* from a source PostgreSQL DB instance with an ARN set to *postgresqlmasterARN*, associated with a DB subnet group named *mysubnetgroup* and a VPC security group named *mysecuritygroup*\.
 
 **Example**  
 
@@ -140,7 +140,7 @@ https://rds.us-east-1.amazonaws.com/
     &DBClusterIdentifier=myreadreplicacluster
     &DBSubnetGroupName=mysubnetgroup
     &Engine=aurora-postgresql
-    &ReplicationSourceIdentifier=mysqlmasterARN
+    &ReplicationSourceIdentifier=postgresqlmasterARN
     &SignatureMethod=HmacSHA256
     &SignatureVersion=4
     &Version=2014-10-31


### PR DESCRIPTION
Description of changes:

Some references to MySQL on this guide are incorrect, as this is a guide to migrate from a PostgreSQL DB Instance to an Aurora PostgreSQL DB Cluster.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
