### PR TITLE
Update max number of cross-region read replicas

### DIFF
--- a/doc_source/AuroraMySQL.Replication.CrossRegion.md
+++ b/doc_source/AuroraMySQL.Replication.CrossRegion.md
@@ -334,7 +334,7 @@ You receive this error if you have updated the `binlog_format` DB cluster parame
 
 ### Source cluster \[DB cluster ARN\] already has a read replica in this region<a name="AuroraMySQL.Replication.CrossRegion.Troubleshooting.3"></a>
 
-You can only have one cross\-region DB cluster that is a Read Replica for each source DB cluster in any AWS Region\. To create a new cross\-region DB cluster that is a Read Replica in a particular AWS Region, you must delete the existing one\.
+You can only have five cross\-region DB clusters that are Read Replicas for each source DB cluster in any AWS Region\. To create a new cross\-region DB cluster that is a Read Replica in a particular AWS Region, you must delete an existing one\.
 
 ### DB cluster \[DB cluster ARN\] requires a database engine upgrade for cross\-region replication support<a name="AuroraMySQL.Replication.CrossRegion.Troubleshooting.4"></a>
 


### PR DESCRIPTION
*Description of changes:*

According to https://aws.amazon.com/about-aws/whats-new/2018/09/amazon-aurora-databases-support-up-to-five-cross-region-read-replicas/ the max number of cross-region read replicas was modified from 1 to 5. I encountered this difference in documentation today, and wanted to update it to match the current max.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
