### PR TITLE
Update Aurora IAM conditions documentation

### DIFF
--- a/doc_source/UsingWithRDS.IAM.Conditions.md
+++ b/doc_source/UsingWithRDS.IAM.Conditions.md
@@ -16,9 +16,6 @@ There are two ways to specify conditions in an IAM policy for Amazon RDS:
 
 AWS provides a set of predefined condition keys \(AWS\-wide condition keys\) for all AWS services that support IAM for access control\. For example, you can use the `aws:userid` condition key to require a specific AWS ID when requesting an action\. For more information and a list of the AWS\-wide condition keys, see [Available Keys for Conditions](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html#AvailableKeys) in the *IAM User Guide*\.
 
-**Note**  
-Condition keys are case sensitive\.
-
 In addition Amazon RDS also provides its own condition keys that you can include in `Condition` elements in an IAM permissions policy\. The following table shows the RDS condition keys that apply to RDS resources\. 
 
 [\[See the AWS documentation website for more details\]](http://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.IAM.Conditions.html)


### PR DESCRIPTION
Removed note 'condition keys are case sensitive' as per IAM documentation here https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition.html stating that condition keys are not case sensitive.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
