### PR TITLE
Adding db.r5 to the list of instance classes

### DIFF
--- a/doc_source/aurora-mysql-parallel-query.md
+++ b/doc_source/aurora-mysql-parallel-query.md
@@ -55,6 +55,7 @@
 +  Currently, you can only use parallel query with the following instance classes: 
   +  All instance types in the db\.r3 series\. 
   +  All instance types in the db\.r4 series\. 
+  +  All instance types in the db\.r5 series\. 
 **Note**  
  You can't create T2 instances for parallel query\. 
 +  The parallel query option is available in the following regions: 


### PR DESCRIPTION
Parallel query works on r5s, the docs should reflect this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
