### PR TITLE
Conditionalize title for 'Limits' chapter

### DIFF
--- a/doc_source/CHAP_Limits.md
+++ b/doc_source/CHAP_Limits.md
@@ -1,4 +1,4 @@
-# Limits for Amazon RDS<a name="CHAP_Limits"></a>
+# Limits for Amazon Aurora<a name="CHAP_Limits"></a>
 
 This topic describes the resource limits and naming constraints for Amazon Aurora\.
 


### PR DESCRIPTION
Right now the <title> element in XML hardcodes the &RDS; entity. Conditionalize so the title references &AUR; when displayed in the Aurora Guide.

(Using this minor glitch that I noticed as a test of the edit-in-github process.)

*Issue #, if available:*

*Description of changes:*

I don't know why the diff shows changes in a paragraph within the page. I only edited the 1 line with the page title.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
