### PR TITLE
Postgres only support t3's on 10.7 or later

### DIFF
--- a/doc_source/Concepts.DBInstanceClass.md
+++ b/doc_source/Concepts.DBInstanceClass.md
@@ -86,7 +86,7 @@ The following are DB engine considerations for DB instance classes:
 | db\.t3\.2xlarge\* | 8 | Variable | 32 | Up to 2,048 | Up to 5 Gbps | No | No | 
 | db\.t3\.xlarge\* | 4 | Variable | 16 | Up to 2,048 | Up to 5 Gbps | No | No | 
 | db\.t3\.large\* | 2 | Variable | 8 | Up to 2,048 | Up to 5 Gbps | No | No | 
-| db\.t3\.medium\* | 2 | Variable | 4 | Up to 1,536 | Up to 5 Gbps | 1\.14\.4 and later | Yes | 
+| db\.t3\.medium\* | 2 | Variable | 4 | Up to 1,536 | Up to 5 Gbps | 1\.14\.4 and later | 10\.7 and later | 
 | db\.t3\.small\* | 2 | Variable | 2 | Up to 1,536 | Up to 5 Gbps | 1\.14\.4 and later | No | 
 | db\.t3\.micro\* | 2 | Variable | 1 | Up to 1,536 | Up to 5 Gbps | No | No | 
 | db\.t2 – Current Generation Burstable Performance Instance Classes | 


### PR DESCRIPTION
*Description of changes:*

Mark t3.mediums as requiring postgres 10.7 so that it matches this statement earlier in the documentation:

> Aurora PostgreSQL supports only the db.t3.medium instance class for versions compatible with PostgreSQL 10.7 or later. These instance classes are available for Aurora PostgreSQL in all Aurora regions except China (Ningxia).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
