### PR TITLE
add new instance types supported by AuroraPG

### DIFF
--- a/doc_source/AuroraPostgreSQL.Managing.md
+++ b/doc_source/AuroraPostgreSQL.Managing.md
@@ -41,7 +41,9 @@ The following table lists the resulting default value of `max_connections` for e
 | db\.r5\.xlarge | 3300 | 
 | db\.r5\.2xlarge | 5000 | 
 | db\.r5\.4xlarge | 5000 | 
+| db\.r5\.8xlarge | 5000 | 
 | db\.r5\.12xlarge | 5000 | 
+| db\.r5\.16xlarge | 5000 | 
 | db\.r5\.24xlarge | 5000 | 
 | db\.t3\.medium | 420 | 
 


### PR DESCRIPTION
Aurora Postgresql support for db.r5.8xlarge and 16xlarge instance types was added recently, but missing from this document

*Issue #, if available:*

*Description of changes:*
Added both new instance types to the table

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
