### PR TITLE
Adding new instance types now supported by AuroraPG

### DIFF
--- a/doc_source/AuroraPostgreSQL.Managing.md
+++ b/doc_source/AuroraPostgreSQL.Managing.md
@@ -42,7 +42,9 @@ The following table lists the resulting default value of `max_connections` for e
 | db\.r5\.xlarge | 3300 | 
 | db\.r5\.2xlarge | 5000 | 
 | db\.r5\.4xlarge | 5000 | 
+| db\.r5\.8xlarge | 5000 | 
 | db\.r5\.12xlarge | 5000 | 
+| db\.r5\.16xlarge | 5000 | 
 | db\.r5\.24xlarge | 5000 | 
 | db\.t3\.medium | 420 | 
 


### PR DESCRIPTION
Adding new instance types db.r5.8xlarge and db.r5.16xlarge now supported by AuroraPG

*Issue #, if available:*
New instances types db.r5.8xlarge and 16xlarge are not listed in the max connections table
*Description of changes:*
Added missing instance types to the table

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
