### PR TITLE
Update query-editor.md

### DIFF
--- a/doc_source/query-editor.md
+++ b/doc_source/query-editor.md
@@ -8,6 +8,7 @@ The query editor requires an Aurora Serverless DB cluster with the Data API enab
 
 The query editor is only available for the following Aurora Serverless DB clusters:
 + Aurora with MySQL version 5\.6 compatibility
++ Aurora with MySQL version 5\.7 compatibility
 + Aurora with PostgreSQL version 10\.7 compatibility
 
 The query editor is currently available for Aurora Serverless in the following AWS Regions:


### PR DESCRIPTION
Query Editor now available with MySQL version 5.7 compatibility.  Ref: https://aws.amazon.com/about-aws/whats-new/2020/06/announcing-aurora-serverless-with-mysql-5-7-compatibility/

*Issue #, if available:*

*Description of changes:*

Query Editor now available with MySQL version 5.7 compatibility.  Ref: https://aws.amazon.com/about-aws/whats-new/2020/06/announcing-aurora-serverless-with-mysql-5-7-compatibility/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
