### PR TITLE
Corrected usage for rds_set_external_master

### DIFF
--- a/doc_source/AuroraMySQL.Migrating.ExtMySQL.md
+++ b/doc_source/AuroraMySQL.Migrating.ExtMySQL.md
@@ -441,7 +441,7 @@ If `REQUIRE SSL` is not included, the replication connection might silently fall
    CALL mysql.rds_set_external_master(
      'Externaldb.some.com',
      3306,
-     'repl_user'@'mydomain.com',
+     'repl_user',
      'password',
      'mysql-bin.000010',
      120,


### PR DESCRIPTION
https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/mysql_rds_set_external_master.html only accepts a single string for username, not `'user'@'host'`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
