### PR TITLE
Not all DDL ends PostgreSQL transactions

### DIFF
--- a/doc_source/rds-proxy.howitworks.md
+++ b/doc_source/rds-proxy.howitworks.md
@@ -112,7 +112,7 @@
  All the statements within a single transaction always use the same underlying database connection\. The connection becomes available for use by a different session when the transaction ends\. Using the transaction as the unit of granularity has the following consequences: 
 +  Connection reuse can happen after each individual statement when the RDS for MySQL or Aurora MySQL `autocommit` setting is enabled\. 
 +  Conversely, when the `autocommit` setting is disabled, the first statement you issue in a session begins a new transaction\. Thus, if you enter a sequence of `SELECT`, `INSERT`, `UPDATE`, and other data manipulation language \(DML\) statements, connection reuse doesn't happen until you issue a `COMMIT`, `ROLLBACK`, or otherwise end the transaction\. 
-+  Entering a data definition language \(DDL\) statement causes the transaction to end after that statement completes\. 
++  Entering a data definition language \(DDL\) statement causes the transaction to end after that statement completes when using MySQL\.  [Some DDL statements are supported without ending transactions in PostgreSQL](https://wiki.postgresql.org/wiki/Transactional_DDL_in_PostgreSQL:_A_Competitive_Analysis#Transactional_DDL)\. 
 
  RDS Proxy detects when a transaction ends through the network protocol used by the database client application\. Transaction detection doesn't rely on keywords such as `COMMIT` or `ROLLBACK` appearing in the text of the SQL statement\. 
 


### PR DESCRIPTION
*Description of changes:*

The documentation had listed that DDL ends transactions - this is not true for PostgreSQL.

From my reading, MariaDB is not supported by these proxies, but it does support DDL in transactions in case that's relevant to Aurora: https://mariadb.com/kb/en/start-transaction/#ddl-statements

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.