### PR TITLE
Corrects a typo in the AuroraMySQL.Updates.MajorVersionUpgrade.md file

### DIFF
--- a/doc_source/AuroraMySQL.Updates.MajorVersionUpgrade.md
+++ b/doc_source/AuroraMySQL.Updates.MajorVersionUpgrade.md
@@ -50,7 +50,7 @@ To make sure that your applications and administration procedures work smoothly 
 
 To learn the sorts of issues that you might encounter during the upgrade, see [Troubleshooting for Aurora MySQL in\-place upgrade](#AuroraMySQL.Upgrading.Troubleshooting)\. For issues that might cause the upgrade to take a long time, you can test those conditions in advance and correct them\.
 
-You can check application compatibility, performance, maintenance procedures, and similar considerations for the upgraded cluster\. To do so, you can perform a simulation of the upgrade before doing the real upgrade\. This technique can be especially useful for production clusters\. Here, it's important to minimize downtime and have the upgraded cluster ready to go as soon as the upgrade as finished\.
+You can check application compatibility, performance, maintenance procedures, and similar considerations for the upgraded cluster\. To do so, you can perform a simulation of the upgrade before doing the real upgrade\. This technique can be especially useful for production clusters\. Here, it's important to minimize downtime and have the upgraded cluster ready to go as soon as the upgrade has finished\.
 
 Use the following steps:
 


### PR DESCRIPTION
The word 'as' is used when it should be 'has'.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
