### PR TITLE
Add Aurora Serverless v2 to Limitations

### DIFF
--- a/doc_source/rds-secrets-manager.md
+++ b/doc_source/rds-secrets-manager.md
@@ -304,6 +304,7 @@ Feature availability and support varies across specific versions of each databas
 Managing master user passwords with Secrets Manager isn't supported for the following features:
 + Amazon RDS Blue/Green Deployments
 + DB clusters that are part of an Aurora global database
++ Aurora Serverless v2 DB clusters
 + Aurora Serverless v1 DB clusters
 + Aurora MySQL cross\-Region read replicas
 + Managing master user password with Secrets Manager for a read replica


### PR DESCRIPTION
*Description of changes:*
It seems like Aurora Serverless v2 is also not possible (at least with Postgres) when using passwords managed by Secrets Manager

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
